### PR TITLE
Fixed the bug that causes the restaurants with same name to not render

### DIFF
--- a/client/src/BusinessCard/BusinessCard.js
+++ b/client/src/BusinessCard/BusinessCard.js
@@ -54,8 +54,7 @@ class BusinessCard extends Component {
     const url = "/api/yelp/search?";
     let data = this.retrieveData();
     let urlParams = Object.entries(data).map(e => e.join('=')).join('&');
-    this.setState({ loading: true });
-    this.setState({ mainBusiness: null });
+    this.setState({ loading: true, mainBusiness: null });
     fetch(url + urlParams)
       .then(response => response.json())
       .then(data => {

--- a/client/src/BusinessCard/BusinessCard.js
+++ b/client/src/BusinessCard/BusinessCard.js
@@ -55,6 +55,7 @@ class BusinessCard extends Component {
     let data = this.retrieveData();
     let urlParams = Object.entries(data).map(e => e.join('=')).join('&');
     this.setState({ loading: true });
+    this.setState({ mainBusiness: null });
     fetch(url + urlParams)
       .then(response => response.json())
       .then(data => {
@@ -62,9 +63,6 @@ class BusinessCard extends Component {
           this.setState({ businessesMemo: data.jsonBody.businesses });
           if(this.state.businessesMemo.length > 0){
             this.setState({ mainBusiness: this.state.businessesMemo[0]});
-          }
-          else{
-            this.setState({ mainBusiness: null });
           }
           this.setState({ loading: false });
         }
@@ -109,7 +107,15 @@ class BusinessCard extends Component {
             )
             : ( this.state.loading === true
                 ? (<CircularProgress />)
-                : (null)
+                : ( this.props.storeName
+                    ? ( <Card style={{ padding: "1%"}}>
+                          <Typography variant="h5" component="h2">
+                            Sorry! We do not have a review for {this.props.storeName}!
+                          </Typography>
+                        </Card>
+                      )
+                    : (null)
+                )
             )
           }
       </div>


### PR DESCRIPTION
Updates:
 - Fixed a bug that causes restaurants with same name to not render properly. (e.g. When clicking on one of the McDonald's in the area and then clicking on another McDonald's in the same area will not render the latest restaurant that was clicked)
 - Added a default case when there's no ratings that can be found on a certain unknown restaurant.

Hours Spent: 1

@zhuoyingcai Could you confirm that the Dunkin Donuts' bug is resolved? 